### PR TITLE
change: NiGui::PostProcessComponents()のmax変数の型変更

### DIFF
--- a/NiGui.cpp
+++ b/NiGui.cpp
@@ -382,7 +382,7 @@ void NiGui::PostProcessComponents()
 
     if (componentID.typeActive == "DragItem" && !componentID.active.empty())
     {
-        int max = 0;
+        uint32_t max = 0;
         for (auto& itr : dragItemData_)
         {
             if (itr.second.zOrder > max)


### PR DESCRIPTION
## NiGuiクラス

* `NiGui.cpp` の `void NiGui::PostProcessComponents()` 関数において、変数 `max` の型が `int` から `uint32_t` に変更されました。
  * これにより、`max` 変数が符号なし32ビット整数として扱われるようになります。