### PR TITLE
feat: ボタンにテクスチャサイズ制御機能を追加

### DIFF
--- a/Impl/Impl_Button.cpp
+++ b/Impl/Impl_Button.cpp
@@ -6,6 +6,7 @@ NiGui_ButtonState NiGui::Button(
     const NiVec4& _color,
     const NiVec2& _position,
     const NiVec2& _size,
+    const NiVec2& _texSize,
     NiGui_StandardPoint _anchor,
     NiGui_StandardPoint _pivot)
 {
@@ -15,6 +16,13 @@ NiGui_ButtonState NiGui::Button(
 
     NiVec2 posInRegion = _position;
     NiVec2 size = size_;
+
+    NiVec2 texSize = _texSize;
+    if (_texSize.Length() == 0.0f)
+    {
+        texSize = _size;
+    }
+
     if (state_.buffer.currentRegion != nullptr)
     {
         posInRegion = _position + state_.buffer.currentRegion->leftTop;
@@ -22,6 +30,7 @@ NiGui_ButtonState NiGui::Button(
     }
 
     auto leftTop = ComputeLeftTop(posInRegion, _size, size, _anchor, _pivot);
+    auto texLeftTop = ComputeLeftTop(posInRegion, texSize, size, _anchor, _pivot);
 
     // 当たり判定
     JudgeClickRect(leftTop, _size, istate);
@@ -34,7 +43,9 @@ NiGui_ButtonState NiGui::Button(
     buttonImage.textureName = _textureName;
     buttonImage.color = _color;
     buttonImage.leftTop = leftTop;
+    buttonImage.texLeftTop = texLeftTop;
     buttonImage.size = _size;
+    buttonImage.texSize = texSize;
     buttonImage.zOrder = state_.buffer.currentZOrder++;
 
     NiGui_ButtonState result = NiGui_ButtonState::None;

--- a/Impl/Impl_Div.cpp
+++ b/Impl/Impl_Div.cpp
@@ -28,7 +28,9 @@ bool NiGui::BeginDiv(const std::string& _id, const std::string& _textureName, co
     divData.textureName = _textureName;
     divData.color = _color;
     divData.leftTop = transformEx.position;
+    divData.texLeftTop = transformEx.position;
     divData.size = transformEx.size;
+    divData.texSize = transformEx.size;
     divData.zOrder = state_.buffer.currentZOrder++;
     divData.parent = state_.buffer.currentRegion;
 
@@ -73,7 +75,9 @@ bool NiGui::BeginDivMovable(const std::string& _id, const std::string& _textureN
     divData.textureName = _textureName;
     divData.color = _color;
     divData.leftTop = transformEx.position;
+    divData.texLeftTop = transformEx.position;
     divData.size = transformEx.size;
+    divData.texSize = transformEx.size;
     divData.zOrder = state_.buffer.currentZOrder++;
     divData.parent = state_.buffer.currentRegion;
 

--- a/Impl/Impl_DragItem.cpp
+++ b/Impl/Impl_DragItem.cpp
@@ -24,7 +24,9 @@ std::string NiGui::DragItemArea(const std::string& _id, const std::string& _text
     areaData.textureName = _textureName;
     areaData.color = _color;
     areaData.leftTop = transformEx.position;
+    areaData.texLeftTop = transformEx.position;
     areaData.size = _size;
+    areaData.texSize = _size;
     areaData.zOrder = state_.buffer.currentZOrder++;
 
     return result;
@@ -130,7 +132,9 @@ std::string NiGui::DragItem(const std::string& _id, const std::string& _textureN
     itemData.textureName = _textureName;
     itemData.color = _color;
     itemData.leftTop = transformEx.position;
+    itemData.texLeftTop = transformEx.position;
     itemData.size = transformEx.size;
+    itemData.texSize = transformEx.size;
     itemData.zOrder = state_.buffer.currentZOrder++;
 
     return result;

--- a/NiGui.h
+++ b/NiGui.h
@@ -57,6 +57,7 @@ public: /// UIコンポーネントの追加
         const NiVec4& _color,
         const NiVec2& _position,
         const NiVec2& _size,
+        const NiVec2& _texSize = {},
         NiGui_StandardPoint _anchor = NiGui_StandardPoint::LeftTop,
         NiGui_StandardPoint _pivot = NiGui_StandardPoint::LeftTop
     );

--- a/Type/NiGui_Type_Component.h
+++ b/Type/NiGui_Type_Component.h
@@ -31,7 +31,9 @@ struct BaseDrawData
     std::string textureName;
     NiVec4 color;
     NiVec2 leftTop;
+    NiVec2 texLeftTop;
     NiVec2 size;
+    NiVec2 texSize;
     uint32_t zOrder;
 };
 


### PR DESCRIPTION
### 概要

UI コンポーネントにおけるテクスチャのサイズと位置を柔軟に制御できる機能を追加しました。これにより、ボタンやその他の UI 要素で、描画されるテクスチャのサイズと位置を個別に指定可能になりました。

---

### 主な変更点

#### NiGui::Button
- `_texSize` パラメータを追加。デフォルト値として空の `NiVec2` を設定。
- `_texSize` が指定されていない場合、デフォルトで `_size` を使用するロジックを追加。
- `ComputeLeftTop` 関数を使用して `texLeftTop` を計算する処理を追加。

#### ButtonData
- `texLeftTop` と `texSize` プロパティを追加し、それらが更新されるように変更。

#### BeginDiv / BeginDivMovable
- `texLeftTop` と `texSize` プロパティを `divData` に追加し、それらが更新されるように変更。

#### DragItemArea / DragItem
- `texLeftTop` と `texSize` プロパティをそれぞれ `areaData` および `itemData` に追加し、それらが更新されるように変更。

#### NiGui.h
- `NiGui::Button` の引数に `_texSize` を追加し、デフォルト値を設定。

#### NiGui_Type_Component.h
- `BaseDrawData` 構造体に `texLeftTop` と `texSize` プロパティを追加。

---

### 互換性
- `_texSize` が指定されていない場合に `_size` をデフォルト値として使用することで、既存のコードとの互換性を維持。

---

### その他
- バイナリファイルや JSON ファイルの変更は含まれていません。