### PR TITLE
feat: UIコンポーネントの引数ラッパーとデータ管理を統一

### DIFF
--- a/Impl/Impl_Button.cpp
+++ b/Impl/Impl_Button.cpp
@@ -10,7 +10,7 @@ NiGui_ButtonState NiGui::Button(
     NiGui_StandardPoint _anchor,
     NiGui_StandardPoint _pivot)
 {
-    auto& buttonImage = buttonImages_[_id];
+    auto& buttonImage = state_.buffer.drawData.button[_id];
     NiGui_InputState istate = {};
     bool isHeld = false;
 
@@ -61,6 +61,20 @@ NiGui_ButtonState NiGui::Button(
     return result;
 }
 
+NiGui_ButtonState NiGui::Button(const NiGui_Arg_Button& _setting)
+{
+    return NiGui::Button(
+        _setting.id,
+        _setting.textureName,
+        _setting.color,
+        _setting.position,
+        _setting.size,
+        _setting.texSize,
+        _setting.anchor,
+        _setting.pivot
+    );
+}
+
 bool NiGui::ButtonBehavior(const std::string& _id, const NiGui_InputState& _inputState, bool& _out_held)
 {
     SetComponentId(_inputState, _id, "Button");
@@ -81,7 +95,7 @@ bool NiGui::ButtonBehavior(const std::string& _id, const NiGui_InputState& _inpu
 
 void NiGui::ButtonDataEnqueue()
 {
-    for(auto& buttonImage : buttonImages_)
+    for(auto& buttonImage : state_.buffer.drawData.button)
     {
         // 描画クラスにデータを追加
         drawer_->EnqueueDrawInfo(&buttonImage.second);

--- a/Impl/Impl_Div.cpp
+++ b/Impl/Impl_Div.cpp
@@ -23,7 +23,7 @@ bool NiGui::BeginDiv(const std::string& _id, const std::string& _textureName, co
     DivBehavior(_id, input.isHover, input.isTrigger);
 
     /// データの更新
-    auto& divData = divData_[_id];
+    auto& divData = state_.buffer.drawData.div[_id];
     divData.id = _id;
     divData.textureName = _textureName;
     divData.color = _color;
@@ -39,6 +39,19 @@ bool NiGui::BeginDiv(const std::string& _id, const std::string& _textureName, co
 
 
     return true;
+}
+
+bool NiGui::BeginDiv(const NiGui_Arg_Div& _setting)
+{
+    return NiGui::BeginDiv(
+        _setting.id,
+        _setting.textureName,
+        _setting.color,
+        _setting.position,
+        _setting.size,
+        _setting.anchor,
+        _setting.pivot
+    );
 }
 
 bool NiGui::BeginDivMovable(const std::string& _id, const std::string& _textureName, const NiVec4& _color, const NiVec2& _position, const NiVec2& _size, const NiGui_StandardPoint _anchor, const NiGui_StandardPoint _pivot)
@@ -70,7 +83,7 @@ bool NiGui::BeginDivMovable(const std::string& _id, const std::string& _textureN
     OffsetUpdate(_id, originLeftTop, transformEx, regionDiff);
 
     /// データの更新
-    auto& divData = divData_[_id];
+    auto& divData = state_.buffer.drawData.div[_id];
     divData.id = _id;
     divData.textureName = _textureName;
     divData.color = _color;
@@ -85,6 +98,19 @@ bool NiGui::BeginDivMovable(const std::string& _id, const std::string& _textureN
     state_.buffer.currentRegion = dynamic_cast<BaseRegionData*>(&divData);
 
     return true;
+}
+
+bool NiGui::BeginDivMovable(const NiGui_Arg_Div& _setting)
+{
+    return NiGui::BeginDivMovable(
+        _setting.id,
+        _setting.textureName,
+        _setting.color,
+        _setting.position,
+        _setting.size,
+        _setting.anchor,
+        _setting.pivot
+    );
 }
 
 void NiGui::EndDiv()
@@ -109,7 +135,7 @@ void NiGui::DivBehavior(const std::string& _id, bool _isHover, bool _isTrigger)
 
 void NiGui::DivDataEnqueue()
 {
-    for (auto& divData : divData_)
+    for (auto& divData : state_.buffer.drawData.div)
     {
         // 描画クラスにデータを追加
         drawer_->EnqueueDrawInfo(&divData.second);

--- a/Interface/NiGui_IDebug.cpp
+++ b/Interface/NiGui_IDebug.cpp
@@ -1,0 +1,46 @@
+﻿#include "NiGui_IDebug.h"
+
+bool INiGuiDebug::GetComponentData(const std::string& _id, BaseDrawData& _out_data)
+{
+    bool isfound = false;
+    auto& drawData = state_->buffer.drawData;
+
+    auto buttonItr = drawData.button.find(_id.c_str());
+    isfound = isfound || (buttonItr != drawData.button.end());
+
+    if (isfound)
+    {
+        _out_data = buttonItr->second;
+        return true;
+    }
+
+    auto divItr = drawData.div.find(_id.c_str());
+    isfound = isfound || (divItr != drawData.div.end());
+
+    if (isfound)
+    {
+        _out_data = divItr->second;
+        return true;
+    }
+
+    auto dragItemItr = drawData.dragItem.find(_id.c_str());
+    isfound = isfound || (dragItemItr != drawData.dragItem.end());
+
+    if (isfound)
+    {
+        _out_data = dragItemItr->second;
+        return true;
+    }
+
+    auto dragItemAreaItr = drawData.dragItemArea.find(_id.c_str());
+    isfound = isfound || (dragItemAreaItr != drawData.dragItemArea.end());
+
+    if (isfound)
+    {
+        _out_data = dragItemAreaItr->second;
+        return true;
+    }
+
+    // 見つからなかったら
+    return false;
+}

--- a/Interface/NiGui_IDebug.h
+++ b/Interface/NiGui_IDebug.h
@@ -2,6 +2,9 @@
 
 #include "../Type/NiGui_Type_Core.h"
 
+#include <string>
+#include "../Type/NiGui_Type_Component.h"
+
 class INiGuiDebug
 {
 public:
@@ -15,4 +18,7 @@ protected:
     const NiGuiIO* io_ = nullptr;
     const NiGuiCoreState* state_ = nullptr;
     NiGuiSetting* setting_ = nullptr;
+
+protected:
+    bool GetComponentData(const std::string& _id, BaseDrawData& _out_data);
 };

--- a/NiGui.h
+++ b/NiGui.h
@@ -1,13 +1,14 @@
 #pragma once
 
-#include "Type/NiGui_Type_Component.h" // ComponentTypes
-#include "Type/NiGui_Type_Core.h" // NiGuiCoreState
-#include "Type/NiGui_Type_Various.h" // 
-#include "Type/NiGui_Enum.h" // enums
-#include "math/NiVec2.h" // NiVec2
-#include "Input/NiGui_Input.h" // NiUI_Input
-#include "Interface/NiGui_IDrawer.h"
-#include "Interface/NiGui_IDebug.h"
+#include "./Type/NiGui_Type_Component.h" // ComponentTypes
+#include "./Type/NiGui_Type_Core.h" // NiGuiCoreState
+#include "./Type/NiGui_Type_Various.h"
+#include "./Type/NiGui_Type_Argument.h"
+#include "./Type/NiGui_Enum.h" // enums
+#include "./math/NiVec2.h" // NiVec2
+#include "./Input/NiGui_Input.h" // NiUI_Input
+#include "./Interface/NiGui_IDrawer.h"
+#include "./Interface/NiGui_IDebug.h"
 
 #include <unordered_map> // unordered_map
 #include <string> // string
@@ -62,6 +63,8 @@ public: /// UIコンポーネントの追加
         NiGui_StandardPoint _pivot = NiGui_StandardPoint::LeftTop
     );
 
+    static NiGui_ButtonState Button(const NiGui_Arg_Button& _setting);
+
     // Divの追加
     // textureNameが空の場合はデフォルトの画像が使用されます。
     static bool BeginDiv(
@@ -73,6 +76,8 @@ public: /// UIコンポーネントの追加
         NiGui_StandardPoint _anchor = NiGui_StandardPoint::LeftTop,
         NiGui_StandardPoint _pivot = NiGui_StandardPoint::LeftTop
     );
+
+    static bool BeginDiv(const NiGui_Arg_Div& _setting);
 
     static void EndDiv();
 
@@ -88,6 +93,8 @@ public: /// UIコンポーネントの追加
         const NiGui_StandardPoint _pivot = NiGui_StandardPoint::LeftTop
     );
 
+    static bool BeginDivMovable(const NiGui_Arg_Div& _setting);
+
     static std::string DragItemArea(
         const std::string& _id,
         const std::string& _textureName,
@@ -98,6 +105,8 @@ public: /// UIコンポーネントの追加
         const NiGui_StandardPoint _pivot = NiGui_StandardPoint::LeftTop
     );
 
+    static std::string DragItemArea(const NiGui_Arg_DragItemArea& _setting);
+
     static std::string DragItem(
         const std::string& _id,
         const std::string& _textureName,
@@ -107,6 +116,10 @@ public: /// UIコンポーネントの追加
         const NiGui_StandardPoint _anchor = NiGui_StandardPoint::LeftTop,
         const NiGui_StandardPoint _pivot = NiGui_StandardPoint::LeftTop
     );
+
+    static std::string DragItem(const NiGui_Arg_DragItem& _setting);
+
+    static void SetItemToArea(const std::string& _itemID, const std::string& _areaID);
 
     // 座標自動計算を有効にする
     static void EnableAutoPosition() { state_.flags.autoPosition = true; };
@@ -143,29 +156,23 @@ private: /// メンバ変数
 
     // 確認用フラグ
 
-    static NiGuiIO           io_;
-    static NiGuiCoreState    state_;
-    static NiGuiSetting      setting_;
-    static NiGuiStyle        style_;
+    static NiGuiIO              io_;
+    static NiGuiCoreState       state_;
+    static NiGuiSetting         setting_;
+    static NiGuiStyle           style_;
 
     // 入力データ
-    static NiGui_Input       input_;
+    static NiGui_Input          input_;
 
     // ウィンドウのサイズ
-    static NiVec2           leftTop_;
-    static NiVec2           size_;
+    static NiVec2               leftTop_;
+    static NiVec2               size_;
 
     // 描画クラス
-    static INiGuiDrawer*         drawer_;
+    static INiGuiDrawer*        drawer_;
 
     // デバッグクラス
-    static INiGuiDebug*      debug_;
-
-    // コンポーネントのリスト
-    static std::unordered_map<std::string, ButtonData> buttonImages_;
-    static std::unordered_map<std::string, DivData> divData_;
-    static std::unordered_map<std::string, DragItemAreaData> dragItemAreaData_;
-    static std::unordered_map<std::string, DragItemData> dragItemData_;
+    static INiGuiDebug*         debug_;
 
     // エンドユーザーが変更したデータ
     static std::unordered_map<std::string, NiVec2> divOffset_;

--- a/NiGui.vcxproj
+++ b/NiGui.vcxproj
@@ -170,6 +170,7 @@
     <ClCompile Include="Impl\Impl_Div.cpp" />
     <ClCompile Include="Impl\Impl_DragItem.cpp" />
     <ClCompile Include="Input\NiGui_Input.cpp" />
+    <ClCompile Include="Interface\NiGui_IDebug.cpp" />
     <ClCompile Include="Interface\NiGui_IDrawer.cpp" />
     <ClCompile Include="Math\NiVec2.cpp" />
     <ClCompile Include="Math\NiVec3.cpp" />
@@ -185,6 +186,7 @@
     <ClInclude Include="Math\NiVec4.h" />
     <ClInclude Include="NiGui.h" />
     <ClInclude Include="Type\NiGui_Enum.h" />
+    <ClInclude Include="Type\NiGui_Type_Argument.h" />
     <ClInclude Include="Type\NiGui_Type_Component.h" />
     <ClInclude Include="Type\NiGui_Type_Core.h" />
     <ClInclude Include="Type\NiGui_Type_Various.h" />

--- a/NiGui.vcxproj.filters
+++ b/NiGui.vcxproj.filters
@@ -43,6 +43,9 @@
     <ClCompile Include="Input\NiGui_Input.cpp">
       <Filter>Input</Filter>
     </ClCompile>
+    <ClCompile Include="Interface\NiGui_IDebug.cpp">
+      <Filter>Interface</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Math\NiVec2.h">
@@ -75,6 +78,9 @@
     </ClInclude>
     <ClInclude Include="Input\NiGui_Input.h">
       <Filter>Input</Filter>
+    </ClInclude>
+    <ClInclude Include="Type\NiGui_Type_Argument.h">
+      <Filter>Type</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Type/NiGui_Type_Argument.h
+++ b/Type/NiGui_Type_Argument.h
@@ -1,0 +1,56 @@
+﻿#pragma once
+
+#include "../Math/NiVec2.h"
+#include "../Math/NiVec4.h"
+#include "./NiGui_Enum.h"
+
+#include <string>
+
+/// コンポーネント呼出関数の引数に使用する型の定義
+/// 引数に必要なデータをラップした構造体
+
+
+struct NiGui_Arg_Button
+{
+    std::string id;             // コンポーネントのID
+    std::string textureName;    // テクスチャ名
+    NiVec4 color;               // 色
+    NiVec2 position;            // 左上座標
+    NiVec2 size;                // サイズ
+    NiVec2 texSize;             // テクスチャサイズ
+    NiGui_StandardPoint anchor; // アンカー
+    NiGui_StandardPoint pivot;  // ピボット
+};
+
+struct NiGui_Arg_Div
+{
+    std::string id;             // コンポーネントのID
+    std::string textureName;    // テクスチャ名
+    NiVec4 color;               // 色
+    NiVec2 position;            // 左上座標
+    NiVec2 size;                // サイズ
+    NiGui_StandardPoint anchor; // アンカー
+    NiGui_StandardPoint pivot;  // ピボット
+};
+
+struct NiGui_Arg_DragItemArea
+{
+    std::string id;             // コンポーネントのID
+    std::string textureName;    // テクスチャ名
+    NiVec4 color;               // 色
+    NiVec2 position;            // 左上座標
+    NiVec2 size;                // サイズ
+    NiGui_StandardPoint anchor; // アンカー
+    NiGui_StandardPoint pivot;  // ピボット
+};
+
+struct NiGui_Arg_DragItem
+{
+    std::string id;             // コンポーネントのID
+    std::string textureName;    // テクスチャ名
+    NiVec4 color;               // 色
+    NiVec2 position;            // 左上座標
+    NiVec2 size;                // サイズ
+    NiGui_StandardPoint anchor; // アンカー
+    NiGui_StandardPoint pivot;  // ピボット
+};

--- a/Type/NiGui_Type_Component.h
+++ b/Type/NiGui_Type_Component.h
@@ -5,11 +5,11 @@
 // この構造体はUIクラスの内部で使用されます。
 
 
-#include <string> // string
 #include "../math/NiVec2.h" // NiVec2
 #include "../math/NiVec4.h" // NiVec4
-#include "NiGui_Enum.h" // enums
+#include "./NiGui_Enum.h" // enums
 
+#include <string> // string
 
 // フレックスコンテナのデータ
 struct FlexContainerData

--- a/Type/NiGui_Type_Core.h
+++ b/Type/NiGui_Type_Core.h
@@ -44,6 +44,16 @@ struct NiGuiFlags
     bool autoPosition;
 };
 
+// Included in NiGuiBuffer
+struct NiGuiDrawData
+{
+    StringMap<ButtonData> button;
+    StringMap<DivData> div;
+    StringMap<DragItemAreaData> dragItemArea;
+    StringMap<DragItemData> dragItem;
+};
+
+// Included in NiGuiCoreState
 struct NiGuiBuffer
 {
     BaseRegionData* currentRegion;
@@ -51,6 +61,7 @@ struct NiGuiBuffer
     NiVec2 currentPos;
     BaseDrawData* currentDrawData;
     StringMap<std::string> areaToItem;
+    NiGuiDrawData drawData;
 };
 
 // Included in NiGuiIO


### PR DESCRIPTION
### 概要
- UIコンポーネント関数に引数ラッパー構造体を導入し、コードの可読性と保守性を向上。
- データ管理を `state_.buffer.drawData` に統一し、冗長なデータ構造を削除。
- 新しいデバッグ機能を追加し、コンポーネントデータの取得を可能に。

---

### 主な変更内容

#### **NiGui**
- `NiGui::Button`、`NiGui::BeginDiv`、`NiGui::BeginDivMovable`、`NiGui::DragItemArea`、`NiGui::DragItem`
  - 新しい引数ラッパー構造体（`NiGui_Arg_*`）を使用したオーバーロードを追加。
- `NiGui::ClearData`
  - `state_.buffer.drawData` 内のデータをクリアするように変更。
- `NiGui::PostProcessComponents`
  - `state_.buffer.drawData` を使用してコンポーネントの後処理を実行。
- `NiGui::SetItemToArea`
  - ドラッグアイテムを特定のエリアに関連付ける新機能を追加。
- `NiGui::DragItemBehavior`
  - アイテムがエリア内に収まるように位置を調整するロジックを追加。

#### **デバッグ**
- `INiGuiDebug::GetComponentData`
  - 指定されたIDのコンポーネントデータを取得する新機能を追加。
  - `state_.buffer.drawData` を利用してデータを検索。
- `NiGui_IDebug.cpp`
  - デバッグ関連の実装を分離し、新規ファイルとして追加。

#### **データ管理**
- `state_.buffer.drawData`
  - ボタン、Div、ドラッグアイテムなどのデータを一元管理する仕組みを導入。
- 既存のデータ構造（`buttonImages_`、`divData_`、`dragItemAreaData_`、`dragItemData_`）を削除。

#### **ヘッダー/プロジェクト構成**
- `NiGui_Type_Argument.h`
  - UIコンポーネント関数の引数をラップする構造体を定義。
- `NiGui_Type_Core.h`
  - `NiGuiDrawData` 構造体を追加し、データ管理を統一。
- `NiGui.h`、`NiGui.cpp`、`NiGui_Type_Component.h`、`NiGui_Type_Core.h`
  - インクルードパスを相対パスに修正。
- `NiGui.vcxproj`、`NiGui.vcxproj.filters`
  - 新しいファイル（`NiGui_IDebug.cpp`、`NiGui_Type_Argument.h`）をプロジェクトに追加。

---

### その他
- 新しいデバッグ機能の追加により、開発者がUIコンポーネントの状態を簡単に確認可能に。
- コードのモジュール性、保守性、拡張性を向上。