### PR TITLE
add: 四元数と自由視点カメラの実装を追加

### DIFF
--- a/Math/NiQuaternion.cpp
+++ b/Math/NiQuaternion.cpp
@@ -1,0 +1,125 @@
+﻿#include "./NiQuaternion.h"
+
+#include "./NiVec3.h"
+
+#include <cmath> // std::sqrt
+
+NiQuaternion NiQuaternion::Identity()
+{
+    return NiQuaternion({ 0.0f, 0.0f, 0.0f, 1.0f });
+}
+
+
+NiQuaternion NiQuaternion::Conjugate(const NiQuaternion& _q)
+{
+    return NiQuaternion({ -_q.x, -_q.y, -_q.z, _q.w });
+}
+
+float NiQuaternion::Norm() const
+{
+    return std::sqrt(x * x + y * y + z * z + w * w);
+}
+
+NiQuaternion NiQuaternion::Normalized() const
+{
+    return *this / Norm();
+}
+
+
+NiQuaternion NiQuaternion::Inversed() const
+{
+    return Conjugate(*this) / (x * x + y * y + z * z + w * w);
+}
+
+NiQuaternion NiQuaternion::RotateAxisAngleQuaternion(const NiVec3& _axis, float _angle)
+{
+    float halfAngle = _angle * 0.5f;
+    float cosHalfAngle = std::cos(halfAngle);
+    float sinHalfAngle = std::sin(halfAngle);
+
+    NiQuaternion result = {};
+    result.x = sinHalfAngle * _axis.x;
+    result.y = sinHalfAngle * _axis.y;
+    result.z = sinHalfAngle * _axis.z;
+    result.w = cosHalfAngle;
+
+    return result;
+}
+
+NiQuaternion NiQuaternion::operator+(const NiQuaternion& _rq) const
+{
+    return NiQuaternion({ x + _rq.x, y + _rq.y, z + _rq.z, w + _rq.w });
+}
+
+NiQuaternion NiQuaternion::operator-(const NiQuaternion& _rq) const
+{
+    return NiQuaternion({ x - _rq.x, y - _rq.y, z - _rq.z, w - _rq.w });
+}
+
+NiQuaternion NiQuaternion::operator*(const NiQuaternion& _rq) const
+{
+    NiQuaternion result = {};
+    result.x = w * _rq.x + x * _rq.w + y * _rq.z - z * _rq.y;
+    result.y = w * _rq.y + y * _rq.w + z * _rq.x - x * _rq.z;
+    result.z = w * _rq.z + z * _rq.w + x * _rq.y - y * _rq.x;
+    result.w = w * _rq.w - x * _rq.x - y * _rq.y - z * _rq.z;
+
+    return result;
+}
+
+NiQuaternion NiQuaternion::operator/(float _f) const
+{
+    NiQuaternion result = {};
+    result.x = x / _f;
+    result.y = y / _f;
+    result.z = z / _f;
+    result.w = w / _f;
+
+    return result;
+}
+
+NiQuaternion NiQuaternion::operator-() const
+{
+    return NiQuaternion({ -x, -y, -z, -w });
+}
+
+NiQuaternion NiQuaternion::operator*(float _f) const
+{
+    return NiQuaternion({ x * _f, y * _f, z * _f, w * _f });
+}
+
+NiVec3 FMath::RotateVector(const NiVec3& _v, const NiQuaternion& _q)
+{
+    NiVec3 result = {};
+
+    NiQuaternion q = _q * NiQuaternion({ _v.x, _v.y, _v.z, 0.0f }) * NiQuaternion::Conjugate(_q);
+
+    result.x = q.x;
+    result.y = q.y;
+    result.z = q.z;
+
+    return result;
+}
+
+NiQuaternion NiQuaternion::Slerp(const NiQuaternion& _begin, const NiQuaternion& _end, float _t)
+{
+    float dot = _begin.x * _end.x + _begin.y * _end.y + _begin.z * _end.z + _begin.w * _end.w;
+
+    NiQuaternion begin = _begin;
+
+    if (dot < 0.0f)
+    {
+        begin = -_begin;
+        dot = -dot;
+    }
+
+    /// なす角を求める
+    float theta = std::acos(dot);
+
+    /// thetaとsinを使って補間係数scale0, scale1を求める
+    float sinTheta = std::sin(theta);
+    float scale0 = std::sin((1.0f - _t) * theta) / sinTheta;
+    float scale1 = std::sin(_t * theta) / sinTheta;
+
+    return begin * scale0 + _end * scale1;
+}

--- a/Math/NiQuaternion.h
+++ b/Math/NiQuaternion.h
@@ -1,0 +1,54 @@
+#pragma once
+
+class NiVec3;
+
+/// <summary>
+/// NiQuaternion
+/// </summary>
+class NiQuaternion
+{
+public:
+    /// データ
+    float x,y,z,w;
+
+    /// <returns>単位NiQuaternion</returns>
+    static NiQuaternion Identity();
+
+    /// <returns>共役NiQuaternion</returns>
+    static NiQuaternion Conjugate(const NiQuaternion& _q);
+
+    /// <returns>任意軸回転を表すNiQuaternionの生成</returns>
+    static NiQuaternion RotateAxisAngleQuaternion(const NiVec3& _axis, float _angle);
+
+    /// <returns>ノルム</returns>
+    float Norm() const;
+
+    /// <returns>正規化したNiQuaternion</returns>
+    NiQuaternion Normalized() const;
+
+    /// <returns>逆NiQuaternionを返す</returns>
+    NiQuaternion Inversed() const;
+
+
+    NiQuaternion operator +(const NiQuaternion& _rq) const;
+    NiQuaternion operator -(const NiQuaternion& _rq) const;
+    NiQuaternion operator *(const NiQuaternion& _rq) const;
+    NiQuaternion operator /(float _f) const;
+
+    NiQuaternion operator -() const;
+
+    NiQuaternion operator *(float _f) const;
+
+    /// <summary>
+    /// 球面線形補間
+    /// </summary>
+    /// <param name="_begin">開始</param>
+    /// <param name="_end">終了</param>
+    /// <param name="_t">時間</param>
+    static NiQuaternion Slerp(const NiQuaternion& _begin, const NiQuaternion& _end, float _t);
+};
+
+namespace FMath
+{
+    NiVec3 RotateVector(const NiVec3& _v, const NiQuaternion& _q);
+}

--- a/NiGui.vcxproj
+++ b/NiGui.vcxproj
@@ -172,6 +172,7 @@
     <ClCompile Include="Input\NiGui_Input.cpp" />
     <ClCompile Include="Interface\NiGui_IDebug.cpp" />
     <ClCompile Include="Interface\NiGui_IDrawer.cpp" />
+    <ClCompile Include="Math\NiQuaternion.cpp" />
     <ClCompile Include="Math\NiVec2.cpp" />
     <ClCompile Include="Math\NiVec3.cpp" />
     <ClCompile Include="Math\NiVec4.cpp" />
@@ -181,6 +182,7 @@
     <ClInclude Include="Input\NiGui_Input.h" />
     <ClInclude Include="Interface\NiGui_IDebug.h" />
     <ClInclude Include="Interface\NiGui_IDrawer.h" />
+    <ClInclude Include="Math\NiQuaternion.h" />
     <ClInclude Include="Math\NiVec2.h" />
     <ClInclude Include="Math\NiVec3.h" />
     <ClInclude Include="Math\NiVec4.h" />

--- a/NiGui.vcxproj.filters
+++ b/NiGui.vcxproj.filters
@@ -46,6 +46,9 @@
     <ClCompile Include="Interface\NiGui_IDebug.cpp">
       <Filter>Interface</Filter>
     </ClCompile>
+    <ClCompile Include="Math\NiQuaternion.cpp">
+      <Filter>Math</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Math\NiVec2.h">
@@ -81,6 +84,9 @@
     </ClInclude>
     <ClInclude Include="Type\NiGui_Type_Argument.h">
       <Filter>Type</Filter>
+    </ClInclude>
+    <ClInclude Include="Math\NiQuaternion.h">
+      <Filter>Math</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### 変更内容

#### NiQuaternion クラス
- `NiQuaternion.cpp` を新規追加。
  - 四元数の基本操作（単位四元数、共役、正規化、逆四元数、球面線形補間（Slerp）など）を実装。
  - 四元数の演算子オーバーロード（加算、減算、乗算、スカラー除算など）を実装。
- `NiQuaternion.h` を新規追加。
  - `NiQuaternion` クラスの定義を追加。
  - 四元数を使用したベクトル回転の関数を `FMath` 名前空間内に定義。

#### FreeLookCamera クラス
- `FreeLookCamera.cpp` を新規追加。
  - 自由視点カメラの実装を追加。
  - 四元数を用いてカメラの回転を計算（`NiQuaternion::RotateAxisAngleQuaternion` を使用）。
  - カメラの向きを基にした移動を実現（`FMath::RotateVector` を使用）。
- `FreeLookCamera.h` を新規追加。
  - `FreeLookCamera` クラスの定義を追加。
  - カメラの初期化、更新、移動、回転の操作を提供。

#### プロジェクトファイルの更新
- `NiGui.vcxproj` に `Math\NiQuaternion.cpp` と `Math\NiQuaternion.h` を追加。
- `NiGui.vcxproj.filters` に `Math\NiQuaternion.cpp` と `Math\NiQuaternion.h` を `Math` フィルタに追加。

### 補足
- 四元数を用いたカメラ操作の実装により、スムーズな回転処理が可能になりました。
- プロジェクトファイルの整理により、新規ファイルが適切に統合されています。