### PR TITLE
feat: NiGuiにResetItemToAreaメソッドを追加

### DIFF
--- a/Impl/Impl_DragItem.cpp
+++ b/Impl/Impl_DragItem.cpp
@@ -179,6 +179,11 @@ std::string NiGui::DragItem(const NiGui_Arg_DragItem& _setting)
     );
 }
 
+void NiGui::ResetItemToArea()
+{
+    state_.buffer.areaToItem.clear();
+}
+
 void NiGui::SetItemToArea(const std::string& _itemID, const std::string& _areaID)
 {
     state_.buffer.areaToItem[_areaID] = _itemID;

--- a/NiGui.h
+++ b/NiGui.h
@@ -119,6 +119,7 @@ public: /// UIコンポーネントの追加
 
     static std::string DragItem(const NiGui_Arg_DragItem& _setting);
 
+    static void ResetItemToArea();
     static void SetItemToArea(const std::string& _itemID, const std::string& _areaID);
 
     // 座標自動計算を有効にする


### PR DESCRIPTION
- `Impl_DragItem.cpp` に `NiGui::ResetItemToArea` メソッドを追加し、`state_.buffer.areaToItem` をクリアする機能を実装しました。
- `NiGui.h` に `ResetItemToArea` メソッドの宣言を追加し、クラスのインターフェースを更新しました。
- 既存の `SetItemToArea` メソッドは、アイテムIDとエリアIDを関連付ける機能を引き続き提供します。

バイナリファイルやJSONの変更はありません。