### PR TITLE
feat: UIコンポーネントの描画と判定の改善

### DIFF
--- a/Impl/Impl_Button.cpp
+++ b/Impl/Impl_Button.cpp
@@ -14,8 +14,15 @@ NiGui_ButtonState NiGui::Button(
     NiGui_InputState istate = {};
     bool isHeld = false;
 
+    // 描画用座標
+    NiVec2 leftTopForDraw = {};
+    // 当たり判定用座標
+    NiVec2 leftTopForJudge = {};
+
     NiVec2 posInRegion = _position;
-    NiVec2 size = size_;
+    NiVec2 parentSizeForDraw = io_.windowInfo.clientSize;
+    NiVec2 parentSizeForJudge = size_;
+    float gScale = io_.windowInfo.windowScale;
 
     NiVec2 texSize = _texSize;
     if (_texSize.Length() == 0.0f)
@@ -26,14 +33,16 @@ NiGui_ButtonState NiGui::Button(
     if (state_.buffer.currentRegion != nullptr)
     {
         posInRegion = _position + state_.buffer.currentRegion->leftTop;
-        size = state_.buffer.currentRegion->size;
+        parentSizeForJudge = state_.buffer.currentRegion->size * gScale;
+        parentSizeForDraw = state_.buffer.currentRegion->size;
     }
 
-    auto leftTop = ComputeLeftTop(posInRegion, _size, size, _anchor, _pivot);
-    auto texLeftTop = ComputeLeftTop(posInRegion, texSize, size, _anchor, _pivot);
+    leftTopForJudge = ComputeLeftTop(posInRegion * gScale, _size * gScale, parentSizeForJudge, _anchor, _pivot);
+    leftTopForDraw = ComputeLeftTop(posInRegion, _size, parentSizeForDraw, _anchor, _pivot);
+    auto texLeftTop = ComputeLeftTop(posInRegion, texSize, parentSizeForDraw, _anchor, _pivot);
 
     // 当たり判定
-    JudgeClickRect(leftTop, _size, istate);
+    JudgeClickRect(leftTopForJudge, _size * gScale, istate);
 
     // ボタンの挙動
     bool onButton = ButtonBehavior(_id, istate, isHeld);
@@ -42,7 +51,7 @@ NiGui_ButtonState NiGui::Button(
     buttonImage.id = _id;
     buttonImage.textureName = _textureName;
     buttonImage.color = _color;
-    buttonImage.leftTop = leftTop;
+    buttonImage.leftTop = leftTopForDraw;
     buttonImage.texLeftTop = texLeftTop;
     buttonImage.size = _size;
     buttonImage.texSize = texSize;

--- a/Impl/Impl_DragItem.cpp
+++ b/Impl/Impl_DragItem.cpp
@@ -5,8 +5,9 @@ std::string NiGui::DragItemArea(const std::string& _id, const std::string& _text
     NiGui_Transform2dEx transformEx = {};
     transformEx.position = _position;
     transformEx.size = _size;
+    NiGui_Transform2dEx transformExForDraw = {};
 
-    ComputeRect(transformEx, _anchor, _pivot);
+    ComputeRect(transformEx, transformExForDraw, _anchor, _pivot);
 
     /// =============
     /// 当たり判定と挙動
@@ -133,7 +134,9 @@ std::string NiGui::DragItem(const std::string& _id, const std::string& _textureN
     transformEx.position = _position;
     transformEx.size = _size;
 
-    ComputeRect(transformEx, _anchor, _pivot);
+    NiGui_Transform2dEx transformExForDraw = {};
+
+    ComputeRect(transformEx, transformExForDraw, _anchor, _pivot);
 
     NiVec2 originLeftTop = transformEx.position;
 

--- a/NiGui.cpp
+++ b/NiGui.cpp
@@ -6,11 +6,11 @@
 NiGui_Input         NiGui::input_ = NiGui_Input();
 NiVec2              NiGui::leftTop_ = { 0, 0 };
 NiVec2              NiGui::size_ = { 0, 0 };
-INiGuiDrawer* NiGui::drawer_ = nullptr;
+INiGuiDrawer*       NiGui::drawer_ = nullptr;
 
 NiGuiIO             NiGui::io_ = NiGuiIO();
 NiGuiCoreState      NiGui::state_ = NiGuiCoreState();
-INiGuiDebug* NiGui::debug_ = nullptr;
+INiGuiDebug*        NiGui::debug_ = nullptr;
 NiGuiSetting        NiGui::setting_ = NiGuiSetting();
 NiGuiStyle          NiGui::style_ = NiGuiStyle();
 
@@ -59,6 +59,16 @@ void NiGui::BeginFrame()
 
     // 確認用フラグを立てる
     state_.valid.isBeginFrame = true;
+
+    // ウィンドウ比率の計算
+    if (io_.windowInfo.clientSize != 0.0f)
+    {
+        io_.windowInfo.windowScale = size_.x / io_.windowInfo.clientSize.x;
+    }
+    else
+    {
+        io_.windowInfo.windowScale = 1.0f;
+    }
 
     return;
 }
@@ -329,7 +339,10 @@ void NiGui::OffsetUpdate(
 {
     if (state_.componentID.active == _id)
     {
-        _offset += io_.input.differencePos;
+        if (io_.windowInfo.windowScale != 0.0f)
+        {
+            _offset += io_.input.differencePos / io_.windowInfo.windowScale;
+        }
     }
 
     if (input_.ReleaseLeft() && state_.componentID.active == _id)

--- a/NiGui.h
+++ b/NiGui.h
@@ -131,6 +131,7 @@ public: /// セッター
     static void SetDrawer(INiGuiDrawer* _drawer) { drawer_ = _drawer; }
     static void SetDebug(INiGuiDebug* _debug) { debug_ = _debug; }
     static void SetWindowInfo(const NiVec2& _size, const NiVec2& _leftTop) { size_ = _size; leftTop_ = _leftTop; }
+    static void SetClientSize(const NiVec2& _size) { io_.windowInfo.clientSize = _size; }
     static void SetHoverSound(uint32_t _hoverSE) { io_.audioHnd.buttonHover = _hoverSE; }
     static void SetHoverSound(void* _hoverSE) { io_.audioHandler.buttonHover = _hoverSE; }
     static void SetConfirmSound(uint32_t _confirmSE) { io_.audioHnd.buttonConfirm = _confirmSE; }
@@ -205,7 +206,7 @@ private: /// その他
     static NiVec2 ComputeStandardPoint(NiGui_StandardPoint _stdpoint);
     static NiVec2 ComputeLeftTop(const NiVec2& _position, const NiVec2& _size, const NiVec2& _parentSize, NiGui_StandardPoint _anchor, NiGui_StandardPoint _pivot);
     // 各種座標を取得
-    static void ComputeRect(NiGui_Transform2dEx& _transform, const NiGui_StandardPoint _anchor, const NiGui_StandardPoint _pivot);
+    static void ComputeRect(NiGui_Transform2dEx& _transformForDraw, NiGui_Transform2dEx& _transformForJudge, const NiGui_StandardPoint _anchor, const NiGui_StandardPoint _pivot);
     static void ClearData();
     static void SavePreData();
     static void CopyInputData();

--- a/NiGui.vcxproj
+++ b/NiGui.vcxproj
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug_ASAN|x64">
+      <Configuration>Debug_ASAN</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
@@ -32,7 +36,23 @@
     <CopyCppRuntimeToOutputDir>false</CopyCppRuntimeToOutputDir>
     <UseStructuredOutput>true</UseStructuredOutput>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_ASAN|x64'">
+    <PublicIncludeDirectories>$(MSBuildProjectDirectory);$(PublicIncludeDirectories)</PublicIncludeDirectories>
+    <OutDir>$(MSBuildProjectDirectory)\Bin\$(Configuration)\</OutDir>
+    <IntDir>$(MSBuildProjectDirectory)\Bin\$(Configuration)\Intermediate\</IntDir>
+    <TargetName>$(ProjectName)</TargetName>
+    <CopyLocalDeploymentContent>false</CopyLocalDeploymentContent>
+    <CopyLocalProjectReference>false</CopyLocalProjectReference>
+    <CopyLocalDebugSymbols>false</CopyLocalDebugSymbols>
+    <CopyCppRuntimeToOutputDir>false</CopyCppRuntimeToOutputDir>
+    <UseStructuredOutput>true</UseStructuredOutput>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug_ASAN|x64'">
     <ClCompile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
     </ClCompile>
@@ -57,6 +77,66 @@
       <DiagnosticsFormat>Column</DiagnosticsFormat>
       <SDLCheck>true</SDLCheck>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <SupportJustMyCode>true</SupportJustMyCode>
+      <Optimization>Disabled</Optimization>
+      <InlineFunctionExpansion>Default</InlineFunctionExpansion>
+      <IntrinsicFunctions>false</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Neither</FavorSizeOrSpeed>
+      <EnableFiberSafeOptimizations>false</EnableFiberSafeOptimizations>
+      <WholeProgramOptimization>false</WholeProgramOptimization>
+      <UndefineAllPreprocessorDefinitions>false</UndefineAllPreprocessorDefinitions>
+      <IgnoreStandardIncludePath>false</IgnoreStandardIncludePath>
+      <PreprocessToFile>false</PreprocessToFile>
+      <PreprocessSuppressLineNumbers>false</PreprocessSuppressLineNumbers>
+      <PreprocessKeepComments>false</PreprocessKeepComments>
+      <MinimalRebuild>false</MinimalRebuild>
+      <DisableLanguageExtensions>false</DisableLanguageExtensions>
+      <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
+      <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
+      <RemoveUnreferencedCodeData>true</RemoveUnreferencedCodeData>
+      <ConformanceMode>true</ConformanceMode>
+      <BuildStlModules>false</BuildStlModules>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <ObjectFileName>$(IntDir)</ObjectFileName>
+      <ProgramDataBaseFileName>$(IntDir)vc$(PlatformToolsetVersion).pdb</ProgramDataBaseFileName>
+      <GenerateSourceDependencies>false</GenerateSourceDependencies>
+      <SourceDependenciesFile>$(IntDir)</SourceDependenciesFile>
+      <BrowseInformation>false</BrowseInformation>
+      <TreatAngleIncludeAsExternal>false</TreatAngleIncludeAsExternal>
+      <ExternalWarningLevel>InheritWarningLevel</ExternalWarningLevel>
+      <CallingConvention>Cdecl</CallingConvention>
+      <CompileAs>Default</CompileAs>
+      <UseFullPaths>true</UseFullPaths>
+      <OmitDefaultLibName>false</OmitDefaultLibName>
+      <ErrorReporting>Prompt</ErrorReporting>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <Lib>
+      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
+    </Lib>
+    <BuildLog>
+      <Path>$(IntDir)$(MSBuildProjectName).log</Path>
+    </BuildLog>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug_ASAN|x64'">
+    <ClCompile>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <SmallerTypeCheck>false</SmallerTypeCheck>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <StructMemberAlignment>Default</StructMemberAlignment>
+      <BufferSecurityCheck>true</BufferSecurityCheck>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard_C>Default</LanguageStandard_C>
+      <AdditionalIncludeDirectories>$(ProjectDir)</AdditionalIncludeDirectories>
+      <ScanSourceForModuleDependencies>false</ScanSourceForModuleDependencies>
+      <TranslateIncludes>false</TranslateIncludes>
+      <WarningLevel>Level3</WarningLevel>
+      <TreatWarningAsError>false</TreatWarningAsError>
+      <DiagnosticsFormat>Column</DiagnosticsFormat>
+      <SDLCheck>true</SDLCheck>
       <SupportJustMyCode>true</SupportJustMyCode>
       <Optimization>Disabled</Optimization>
       <InlineFunctionExpansion>Default</InlineFunctionExpansion>
@@ -204,6 +284,12 @@
     <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_ASAN|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
@@ -212,5 +298,9 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug_ASAN|x64'" Label="PropertySheets">
+    <Import Project="..\..\..\ASAN.props" />
+  </ImportGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/Type/NiGui_Type_Core.h
+++ b/Type/NiGui_Type_Core.h
@@ -98,6 +98,13 @@ struct NiGuiColor
     NiVec4 backGround;
 };
 
+// Included in NiGuiIO
+struct NiGuiWindowInfo
+{
+    NiVec2 clientSize;
+    float windowScale; // ウィンドウのスケール(windowsize / clientsize)
+};
+
 struct NiGuiStyle
 {
     NiGuiColor color;
@@ -113,6 +120,7 @@ struct NiGuiIO
     NiGuiInputData input;
     NiGuiAudioHandle audioHnd;
     NiGuiAudioHandler audioHandler;
+    NiGuiWindowInfo windowInfo;
 };
 
 


### PR DESCRIPTION
* `NiGui_ButtonState NiGui::Button` 関数において、描画用および当たり判定用の座標を計算する新しい変数を追加し、親のサイズやスケールを考慮した計算を実装。
* `NiGui::BeginDiv` 関数で、当たり判定用の変数を追加し、描画用と判定用の座標を別々に計算。
* `NiGui::BeginDivMovable` 関数でも、描画用と判定用の変数を追加し、当たり判定の計算をスケールを考慮して修正。
* `NiGui::ComputeRect` 関数を修正し、描画用と判定用の変数を受け取るように変更。
* `NiGui::DragItemArea` および `NiGui::DragItem` 関数で、描画用の変数を追加し、当たり判定の計算を新しい変数を使用するように変更。
* `NiGui::BeginFrame` 関数にウィンドウの比率を計算するロジックを追加。
* `NiGui.h` に新しい関数 `SetClientSize` を追加し、クライアントサイズを設定可能に。
* プロジェクトファイル `NiGui.vcxproj` にASAN用の新しいビルド構成を追加。
* `NiGui_Type_Core.h` に新しい構造体 `NiGuiWindowInfo` を追加し、ウィンドウのクライアントサイズとスケールを管理。

バイナリファイルやJSONの変更はありません。