### PR TITLE
add: DragItem機能に新しいメソッドを追加

### DIFF
--- a/Impl/Impl_DragItem.cpp
+++ b/Impl/Impl_DragItem.cpp
@@ -187,6 +187,11 @@ void NiGui::ResetItemToArea()
     state_.buffer.areaToItem.clear();
 }
 
+void NiGui::ResetDragItemOffsets()
+{
+    dragItemOffset_.clear();
+}
+
 void NiGui::SetItemToArea(const std::string& _itemID, const std::string& _areaID)
 {
     state_.buffer.areaToItem[_areaID] = _itemID;

--- a/NiGui.h
+++ b/NiGui.h
@@ -120,6 +120,7 @@ public: /// UIコンポーネントの追加
     static std::string DragItem(const NiGui_Arg_DragItem& _setting);
 
     static void ResetItemToArea();
+    static void ResetDragItemOffsets();
     static void SetItemToArea(const std::string& _itemID, const std::string& _areaID);
 
     // 座標自動計算を有効にする


### PR DESCRIPTION
- `Impl_DragItem.cpp` に `ResetDragItemOffsets` メソッドを追加し、`dragItemOffset_` をクリアする機能を実装しました。
- `NiGui.h` に `ResetDragItemOffsets` メソッドの宣言を追加し、クラスのインターフェースを更新しました。

バイナリファイルやJSONの変更はありません。